### PR TITLE
chore: add render build script

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -o errexit
+
+bundle install
+bundle exec rails assets:precompile
+bundle exec rails assets:clean


### PR DESCRIPTION
## 概要
Render でのデプロイ時に必要な build script を追加しました。

## 変更内容
- `bin/render-build.sh` を追加
- build 時に以下を実行するよう設定
  - `bundle install`
  - `rails assets:precompile`
  - `rails assets:clean`

## 背景
Render の Build Command を `bin/render-build.sh` にしていたが、
`main` ブランチ上に対象ファイルが存在せず、デプロイが失敗していたため対応しました。

## 確認事項
- `bin/render-build.sh` が実行可能になっていること
- Render 側で再デプロイ

closes #26 