### PR TITLE
add: トップページ追加、レイアウト作成

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,4 @@
+class PagesController < ApplicationController
+  def top
+  end
+end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,0 +1,2 @@
+module PagesHelper
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,14 +6,13 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
-
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
-    <main class="container mx-auto mt-28 px-5 flex">
-      <%= yield %>
-    </main>
+  <body class="min-h-screen bg-gray-100 flex flex-col">
+    <%= render "shared/header" %>
+    <%= yield %>
+    <%= render "shared/footer" %>
   </body>
 </html>

--- a/app/views/pages/top.html.erb
+++ b/app/views/pages/top.html.erb
@@ -1,0 +1,49 @@
+<main class="flex-1">
+  <div class="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 md:py-10 lg:px-8 lg:py-12">
+    <section class="overflow-hidden rounded-2xl bg-white shadow-sm">
+      <div class="grid min-h-[calc(100vh-220px)] grid-cols-1 lg:grid-cols-2">
+        <div class="flex items-center justify-center bg-gray-100 p-8 sm:p-10 lg:p-16">
+          <div class="w-full max-w-xl text-center lg:text-left">
+            <p class="mb-4 inline-block rounded-full bg-green-100 px-4 py-2 text-sm font-bold text-green-700 sm:text-base">
+              毎日の運動を、成長の楽しみに
+            </p>
+            <h1 class="mb-6 text-4xl font-bold leading-tight text-green-700 sm:text-5xl lg:text-6xl">
+              Walk Plant Growth
+            </h1>
+            <p class="mb-8 text-base leading-relaxed text-gray-700 sm:text-lg lg:text-xl">
+              運動を記録して、植物を育てよう。<br class="hidden sm:block">
+              毎日の小さな積み重ねが、植物の成長として見えるアプリです。
+            </p>
+
+            <div class="flex flex-col gap-3 sm:flex-row sm:justify-center lg:justify-start">
+              <a href="#" class="rounded-lg bg-green-600 px-6 py-3 text-center text-base font-bold text-white hover:bg-green-700 sm:text-lg">
+                はじめる
+              </a>
+              <a href="#" class="rounded-lg border border-green-600 px-6 py-3 text-center text-base font-bold text-green-700 hover:bg-green-50 sm:text-lg">
+                ログイン
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex items-center justify-center bg-green-50 p-8 sm:p-10 lg:p-16">
+          <div class="flex h-[280px] w-full max-w-xl items-center justify-center rounded-2xl border-2 border-dashed border-green-200 bg-white text-center sm:h-[360px] lg:h-[480px]">
+            <div>
+              <p class="text-xl font-bold text-green-700 sm:text-2xl lg:text-3xl">
+                植物イメージエリア
+              </p>
+              <p class="mt-3 text-sm text-gray-500 sm:text-base">
+                後でキービジュアルやアプリ説明画像を配置
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="mt-8 flex flex-wrap justify-center gap-x-8 gap-y-4 text-sm text-gray-700 underline sm:mt-10 sm:text-base lg:text-lg">
+      <a href="#">プライバシーポリシー</a>
+      <a href="#">利用規約</a>
+    </div>
+  </div>
+</main>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,15 @@
+<footer class="bg-green-600 text-white">
+  <div class="grid h-16 grid-cols-4 items-center text-center text-sm font-bold sm:h-20 sm:text-base md:hidden">
+    <a href="#" class="hover:opacity-80">ホーム</a>
+    <a href="#" class="hover:opacity-80">運動記録</a>
+    <a href="#" class="hover:opacity-80">投稿</a>
+    <a href="#" class="hover:opacity-80">マイページ</a>
+  </div>
+
+  <div class="hidden md:flex mx-auto max-w-7xl items-center justify-center gap-12 px-8 py-5 text-base font-bold">
+    <a href="#" class="hover:opacity-80">ホーム</a>
+    <a href="#" class="hover:opacity-80">運動記録</a>
+    <a href="#" class="hover:opacity-80">投稿</a>
+    <a href="#" class="hover:opacity-80">マイページ</a>
+  </div>
+</footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,12 @@
+<header class="bg-green-600 text-white">
+  <div class="mx-auto flex h-16 w-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+    <div class="text-2xl font-bold sm:text-3xl">
+      <%= link_to "LOGO", root_path %>
+    </div>
+
+    <div class="flex items-center gap-3 sm:gap-6">
+      <%= link_to "ログイン", "#", class: "text-sm font-bold hover:opacity-80 sm:text-lg lg:text-xl" %>
+      <%= link_to "新規登録", "#", class: "bg-amber-400 px-3 py-2 text-sm font-bold text-white hover:bg-amber-500 sm:px-5 sm:text-base lg:text-lg" %>
+    </div>
+  </div>
+</header>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  root "pages#top"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class PagesControllerTest < ActionDispatch::IntegrationTest
+  test "should get top" do
+    get pages_top_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
未ログインユーザー向けのトップページと、共通ヘッダー・フッターを実装しました。

## 変更内容
- `PagesController#top` をトップページとして設定
- `root "pages#top"` を追加
- 未ログイン時にサービス概要が分かる
- 共通ヘッダー / 共通フッターをpartialで作成
- `application.html.erb` に共通レイアウトを適用

## 確認方法
- `http://localhost:3000` にアクセス
- トップページが表示されることを確認
- PC幅 / スマホ幅でレイアウトが崩れないことを確認

## 補足
- ログイン / 新規登録 / 各フッターリンクは現時点ではダミーです
- キービジュアル部分は仮置きです
- ログイン状態でのヘッダー分岐はログイン機能実装時に対応します。

Closes #5 