### PR TITLE
feat: マイページ作成、プロフィール編集機能追加

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,0 +1,28 @@
+class MypagesController < ApplicationController
+  before_action :require_login
+
+  def show
+    @user = current_user
+  end
+
+  def edit
+    @user = current_user
+  end
+
+  def update
+    @user = current_user
+
+    if @user.update(mypage_params)
+      redirect_to mypage_path, notice: "プロフィールを更新しました"
+    else
+      flash.now[:alert] = @user.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def mypage_params
+    params.require(:user).permit(:display_name, :profile_image)
+  end
+end

--- a/app/helpers/mypages_helper.rb
+++ b/app/helpers/mypages_helper.rb
@@ -1,0 +1,2 @@
+module MypagesHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  has_one_attached :profile_image
+
   has_many :user_plants, dependent: :destroy
   has_many :plants, through: :user_plants
 

--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -1,0 +1,34 @@
+<main class="flex-1 bg-gray-100 py-10">
+  <div class="mx-auto w-full max-w-3xl px-4">
+    <div class="rounded-2xl bg-white p-6 shadow-sm sm:p-8">
+      <h1 class="mb-6 text-2xl font-bold text-green-700 sm:text-3xl">
+        プロフィール編集
+      </h1>
+
+      <% if flash.now[:alert].present? %>
+        <div class="mb-4 rounded-lg bg-red-100 px-4 py-3 text-sm text-red-700">
+          <%= flash.now[:alert] %>
+        </div>
+      <% end %>
+
+      <%= form_with model: @user, url: mypage_path, method: :patch, local: true, class: "space-y-6" do |f| %>
+        <div>
+          <%= f.label :display_name, "ユーザー名", class: "mb-2 block text-sm font-bold text-gray-700" %>
+          <%= f.text_field :display_name,
+                class: "w-full rounded-lg border border-gray-300 px-4 py-3 focus:border-green-500 focus:outline-none" %>
+        </div>
+
+        <div>
+          <%= f.label :profile_image, "プロフィール画像", class: "mb-2 block text-sm font-bold text-gray-700" %>
+          <%= f.file_field :profile_image,
+                class: "w-full rounded-lg border border-gray-300 px-4 py-3 focus:border-green-500 focus:outline-none" %>
+        </div>
+
+        <div>
+          <%= f.submit "更新する",
+                class: "w-full rounded-lg bg-green-600 px-4 py-3 font-bold text-white hover:bg-green-700" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</main>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,0 +1,32 @@
+<main class="flex-1 bg-gray-100 py-10">
+  <div class="mx-auto w-full max-w-3xl px-4">
+    <div class="rounded-2xl bg-white p-6 shadow-sm sm:p-8">
+      <h1 class="mb-6 text-2xl font-bold text-green-700 sm:text-3xl">
+        マイページ
+      </h1>
+
+      <div class="mb-8 flex flex-col items-center gap-4 sm:flex-row sm:items-start">
+        <div class="flex h-28 w-28 items-center justify-center overflow-hidden rounded-full bg-gray-200">
+          <% if @user.profile_image.attached? %>
+            <%= image_tag @user.profile_image, class: "h-full w-full object-cover" %>
+          <% else %>
+            <span class="text-sm text-gray-500">No Image</span>
+          <% end %>
+        </div>
+
+        <div class="text-center sm:text-left">
+          <p class="text-lg font-bold text-gray-800"><%= @user.display_name %></p>
+          <p class="mt-2 text-sm text-gray-600">ユーザーID: <%= @user.name %></p>
+          <p class="mt-2 text-sm text-gray-600">
+            累計獲得ポイント: <span class="font-bold text-green-700"><%= @user.total_growth_points %></span>
+          </p>
+        </div>
+      </div>
+
+      <div>
+        <%= link_to "プロフィールを編集", edit_mypage_path,
+              class: "inline-block rounded-lg bg-green-600 px-5 py-3 font-bold text-white hover:bg-green-700" %>
+      </div>
+    </div>
+  </div>
+</main>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,6 +3,6 @@
     <%= link_to "ホーム", logged_in? ? home_path : root_path, class: "hover:opacity-80" %>
     <%= link_to "運動記録", logged_in? ? "#" : new_signup_email_path, class: "hover:opacity-80" %>
     <%= link_to "投稿", "#", class: "hover:opacity-80" %>
-    <%= link_to "マイページ", logged_in? ? "#" : new_signup_email_path, class: "hover:opacity-80" %>
+    <%= link_to "マイページ", logged_in? ? mypage_path : new_signup_email_path, class: "hover:opacity-80" %>
   </div>
 </footer>

--- a/app/views/shared/_logged_in_header.html.erb
+++ b/app/views/shared/_logged_in_header.html.erb
@@ -26,7 +26,7 @@
         <li><%= link_to "ホーム", home_path, class: "block" %></li>
         <li><%= link_to "運動記録", "#", class: "block" %></li>
         <li><%= link_to "投稿", "#", class: "block" %></li>
-        <li><%= link_to "マイページ", "#", class: "block" %></li>
+        <li><%= link_to "マイページ", mypage_path, class: "block" %></li>
         <li><%= button_to "ログアウト", logout_path, method: :delete, class: "block w-full text-left" %></li>
       </ul>
     </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'mypages/show'
+  get 'mypages/edit'
   get 'password_resets/new'
   get 'password_resets/create'
   get 'password_resets/edit'
@@ -20,6 +22,8 @@ Rails.application.routes.draw do
   delete "logout", to: "sessions#destroy"
 
   resource :password_reset, only: %i[new create edit update]
+
+  resource :mypage, only: %i[show edit update]
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/db/migrate/20260311154830_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20260311154830_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_11_145445) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_11_154830) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "plant_stages", force: :cascade do |t|
     t.bigint "plant_id", null: false
@@ -68,6 +96,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_11_145445) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "plant_stages", "plants"
   add_foreign_key "user_plants", "plants"
   add_foreign_key "user_plants", "users"

--- a/test/controllers/mypages_controller_test.rb
+++ b/test/controllers/mypages_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class MypagesControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get mypages_show_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get mypages_edit_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
マイページの表示・プロフィール編集機能を実装しました。

## 変更内容
- `mypage` のルーティングを追加
- `MypagesController` を作成
- マイページ表示画面を追加
- プロフィール編集画面を追加
- ユーザー名を編集できるように実装
- プロフィール画像を設定できるように実装
- 累計獲得ポイントを表示するように実装
- ログイン後のフッター「マイページ」導線を `mypage_path` に変更

## 確認方法
- ログイン状態で `/mypage` にアクセス
- ユーザー名が表示されることを確認
- 累計獲得ポイントが表示されることを確認
- 「プロフィールを編集」から編集画面へ遷移できることを確認
- ユーザー名を変更して更新できることを確認
- プロフィール画像を設定して更新できることを確認
- 更新後、マイページに変更内容が反映されることを確認

Closes #12 