### PR TITLE
feat: 育成植物変更機能追加

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -2,5 +2,6 @@ class HomesController < ApplicationController
   before_action :require_login
 
   def show
+    @current_user_plant = current_user.user_plants.includes(plant: :plant_stages).find_by(status: :growing)
   end
 end

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -1,0 +1,49 @@
+class PlantsController < ApplicationController
+  before_action :require_login
+
+  def index
+    @current_user_plant = current_user.user_plants.find_by(status: :growing)
+
+    archived_user_plants = current_user.user_plants
+                                      .archived
+                                      .includes(:plant)
+                                      .order(archived_at: :desc, updated_at: :desc)
+
+    @archived_user_plants = archived_user_plants.uniq { |user_plant| user_plant.plant_id }
+
+    if @current_user_plant.present?
+      @archived_user_plants = @archived_user_plants.reject do |user_plant|
+        user_plant.plant_id == @current_user_plant.plant_id
+      end
+    end
+
+    archived_plant_ids = @archived_user_plants.map(&:plant_id)
+    current_growing_plant_id = @current_user_plant&.plant_id
+
+    excluded_ids = archived_plant_ids.dup
+    excluded_ids << current_growing_plant_id if current_growing_plant_id.present?
+
+    @available_plants = Plant.where.not(id: excluded_ids)
+  end
+
+  def select
+    plant = Plant.find(params[:id])
+
+    ActiveRecord::Base.transaction do
+      current_user.user_plants.growing.update_all(
+        status: UserPlant.statuses[:archived],
+        archived_at: Time.current,
+        updated_at: Time.current
+      )
+
+      current_user.user_plants.create!(
+        plant: plant,
+        status: :growing,
+        accumulated_points: 0,
+        selected_at: Time.current
+      )
+    end
+
+    redirect_to home_path, notice: "#{plant.name} に変更しました"
+  end
+end

--- a/app/helpers/plants_helper.rb
+++ b/app/helpers/plants_helper.rb
@@ -1,0 +1,2 @@
+module PlantsHelper
+end

--- a/app/models/user_plant.rb
+++ b/app/models/user_plant.rb
@@ -7,4 +7,24 @@ class UserPlant < ApplicationRecord
   validates :status, presence: true
   validates :accumulated_points, numericality: { greater_than_or_equal_to: 0 }
   validates :selected_at, presence: true
+
+  def current_stage
+    plant.plant_stages
+        .where("required_points <= ?", accumulated_points)
+        .order(required_points: :desc)
+        .first
+  end
+
+  def next_stage
+    plant.plant_stages
+        .where("required_points > ?", accumulated_points)
+        .order(required_points: :asc)
+        .first
+  end
+
+  def points_to_next_stage
+    return 0 unless next_stage
+
+    next_stage.required_points - accumulated_points
+  end
 end

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -1,2 +1,48 @@
-<main class="min-h-[calc(100vh-56px)] bg-white">
+<main class="flex-1 bg-gray-100 py-10">
+  <div class="mx-auto w-full max-w-3xl px-4">
+    <% if @current_user_plant.present? %>
+      <div class="rounded-2xl border border-gray-400 bg-white p-6 shadow-sm">
+        <h1 class="mb-6 text-2xl font-bold text-gray-800">育成中の植物</h1>
+
+        <div class="mb-6 text-right text-lg font-bold text-gray-800">
+          次の成長までに必要なポイント
+          <span class="ml-2 text-green-700"><%= @current_user_plant.points_to_next_stage %>pt</span>
+        </div>
+
+        <div class="mb-8 flex flex-col items-center gap-6 sm:flex-row sm:items-center">
+          <div class="flex h-36 w-36 items-center justify-center rounded-full bg-gray-200 text-sm text-gray-700">
+            植物の画像
+          </div>
+
+          <div class="text-center sm:text-left">
+            <p class="mb-3 text-2xl font-bold text-gray-800">
+              <%= @current_user_plant.plant.name %>
+            </p>
+
+            <p class="text-base text-gray-700">
+              成長段階：
+              <%= @current_user_plant.current_stage&.stage_order || "-" %>
+              （<%= @current_user_plant.current_stage&.name || "未設定" %>）
+            </p>
+          </div>
+        </div>
+
+        <div class="text-center">
+          <%= link_to "他の植物にかえる",
+                plants_path,
+                class: "inline-block rounded-lg bg-green-600 px-8 py-3 font-bold text-white hover:bg-green-700" %>
+        </div>
+      </div>
+    <% else %>
+      <div class="rounded-2xl bg-white p-6 shadow-sm">
+        <p class="mb-4 text-center text-gray-700">現在育成中の植物はありません。</p>
+
+        <div class="text-center">
+          <%= link_to "植物を選ぶ",
+                plants_path,
+                class: "inline-block rounded-lg bg-green-600 px-8 py-3 font-bold text-white hover:bg-green-700" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
 </main>

--- a/app/views/plants/index.html.erb
+++ b/app/views/plants/index.html.erb
@@ -1,0 +1,59 @@
+<main class="flex-1 bg-gray-100 py-10">
+  <div class="mx-auto w-full max-w-4xl px-4">
+    <h1 class="mb-8 text-3xl font-bold text-gray-800">育てられる植物一覧</h1>
+
+    <div class="space-y-4">
+      <% @available_plants.each do |plant| %>
+        <div class="rounded-xl border border-gray-400 bg-white p-4">
+          <div class="flex flex-col gap-4 sm:flex-row">
+            <div class="flex h-24 w-24 items-center justify-center rounded-full bg-gray-200 text-sm text-gray-700">
+              植物の画像
+            </div>
+
+            <div class="flex-1">
+              <p class="mb-2 text-2xl font-bold text-gray-800"><%= plant.name %></p>
+              <p class="mb-2 text-gray-700">
+                開花までに必要なポイント
+                <%= plant.plant_stages.maximum(:required_points) || 0 %>pt
+              </p>
+              <p class="mb-4 text-sm text-gray-700"><%= plant.description %></p>
+
+              <%= button_to "この植物を育てる",
+                    select_plant_path(plant),
+                    method: :post,
+                    class: "rounded-lg bg-green-600 px-6 py-2 font-bold text-white hover:bg-green-700" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+    <h2 class="mt-12 mb-8 text-3xl font-bold text-gray-800">過去育成した植物一覧</h2>
+
+    <div class="space-y-4">
+      <% @archived_user_plants.each do |user_plant| %>
+        <div class="rounded-xl border border-gray-400 bg-white p-4">
+          <div class="flex flex-col gap-4 sm:flex-row">
+            <div class="flex h-24 w-24 items-center justify-center rounded-full bg-gray-200 text-sm text-gray-700">
+              植物の画像
+            </div>
+
+            <div class="flex-1">
+              <p class="mb-2 text-2xl font-bold text-gray-800"><%= user_plant.plant.name %></p>
+              <p class="mb-4 text-gray-700">
+                成長段階：
+                <%= user_plant.current_stage&.stage_order || "-" %>
+                （<%= user_plant.current_stage&.name || "未設定" %>）
+              </p>
+
+              <%= button_to "この植物を育てる",
+                    select_plant_path(user_plant.plant),
+                    method: :post,
+                    class: "rounded-lg bg-green-600 px-6 py-2 font-bold text-white hover:bg-green-700" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'plants/index'
   get 'mypages/show'
   get 'mypages/edit'
   get 'password_resets/new'
@@ -24,6 +25,9 @@ Rails.application.routes.draw do
   resource :password_reset, only: %i[new create edit update]
 
   resource :mypage, only: %i[show edit update]
+
+  resources :plants, only: %i[index]
+  post "plants/:id/select", to: "plants#select", as: :select_plant
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/test/controllers/plants_controller_test.rb
+++ b/test/controllers/plants_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class PlantsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get plants_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
ログイン後ホーム画面で育成中の植物を表示し、別の植物へ切り替えられるように実装しました。

## 変更内容
- ホーム画面に育成中の植物情報を表示するように実装
- 現在の成長段階を表示するように実装
- 次の成長までに必要なポイントを表示するように実装
- 「他の植物にかえる」ボタンから植物一覧画面へ遷移できるように実装
- 植物一覧画面を追加
- 別の植物を選択すると育成中の植物を切り替えられるように実装
- 以前育成した植物も再選択できるように実装
- 過去育成した植物一覧で同じ植物が重複表示されないように修正
- 現在育成中の植物は過去育成一覧に表示しないように修正
- `UserPlant` に成長段階計算用メソッドを追加

## 確認方法
- ログイン状態で `/home` にアクセス
- 育成中の植物が表示されることを確認
- 成長段階と次の成長までに必要なポイントが表示されることを確認
- 「他の植物にかえる」を押して植物一覧画面へ遷移できることを確認
- 一覧から別の植物を選択して育成中の植物を切り替えられることを確認
- 過去育成した植物一覧に同じ植物が重複表示されないことを確認
- 現在育成中の植物が過去育成一覧に表示されないことを確認

Closes #21 