### PR TITLE
feat: 運動記録機能追加

### DIFF
--- a/app/controllers/exercise_logs_controller.rb
+++ b/app/controllers/exercise_logs_controller.rb
@@ -1,0 +1,41 @@
+class ExerciseLogsController < ApplicationController
+  before_action :require_login
+
+  def new
+    @exercise_log = ExerciseLog.new
+  end
+
+  def create
+    current_user_plant = current_user.user_plants.growing.first
+
+    @exercise_log = current_user.exercise_logs.new(exercise_log_params)
+    @exercise_log.user_plant = current_user_plant
+    @exercise_log.earned_points = ExerciseLog.calculate_points(
+      @exercise_log.exercise_type,
+      @exercise_log.duration_minutes
+    )
+
+    ActiveRecord::Base.transaction do
+      @exercise_log.save!
+
+      current_user.increment!(:total_growth_points, @exercise_log.earned_points)
+      current_user_plant&.increment!(:accumulated_points, @exercise_log.earned_points)
+    end
+
+    redirect_to complete_exercise_log_path(points: @exercise_log.earned_points), notice: "運動を記録しました"
+  rescue ActiveRecord::RecordInvalid
+    flash.now[:alert] = @exercise_log.errors.full_messages.join(", ")
+    render :new, status: :unprocessable_entity
+  end
+
+  def complete
+    @earned_points = params[:points].to_i
+    @current_user_plant = current_user.user_plants.includes(plant: :plant_stages).find_by(status: :growing)
+  end
+
+  private
+
+  def exercise_log_params
+    params.require(:exercise_log).permit(:exercise_type, :duration_minutes, :memo)
+  end
+end

--- a/app/helpers/exercise_logs_helper.rb
+++ b/app/helpers/exercise_logs_helper.rb
@@ -1,0 +1,2 @@
+module ExerciseLogsHelper
+end

--- a/app/models/exercise_log.rb
+++ b/app/models/exercise_log.rb
@@ -1,0 +1,31 @@
+class ExerciseLog < ApplicationRecord
+  belongs_to :user
+  belongs_to :user_plant, optional: true
+
+  enum exercise_type: {
+    walk: 0,
+    strength_training: 1,
+    stretching: 2,
+    running: 3,
+    yoga: 4
+  }
+
+  validates :exercise_type, presence: true
+  validates :duration_minutes, presence: true, numericality: { greater_than: 0 }
+  validates :earned_points, presence: true, numericality: { greater_than_or_equal_to: 0 }
+
+  EXERCISE_POINT_RATES = {
+    "walk" => 5,
+    "strength_training" => 8,
+    "stretching" => 4,
+    "running" => 10,
+    "yoga" => 6
+  }.freeze
+
+  def self.calculate_points(exercise_type, duration_minutes)
+    rate = EXERCISE_POINT_RATES[exercise_type]
+    return 0 unless rate
+
+    rate * duration_minutes.to_i
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
 
   has_many :user_plants, dependent: :destroy
   has_many :plants, through: :user_plants
+  has_many :exercise_logs, dependent: :destroy
 
   attr_accessor :password, :password_confirmation
 

--- a/app/models/user_plant.rb
+++ b/app/models/user_plant.rb
@@ -2,6 +2,8 @@ class UserPlant < ApplicationRecord
   belongs_to :user
   belongs_to :plant
 
+  has_many :exercise_logs, dependent: :nullify
+
   enum status: { growing: 0, archived: 1 }
 
   validates :status, presence: true

--- a/app/views/exercise_logs/complete.html.erb
+++ b/app/views/exercise_logs/complete.html.erb
@@ -1,0 +1,34 @@
+<main class="flex-1 bg-gray-100 py-10">
+  <div class="mx-auto w-full max-w-xl px-4">
+    <div class="rounded-2xl bg-white p-6 text-center shadow-sm sm:p-8">
+      <p class="mb-4 text-2xl font-bold text-gray-800 sm:text-3xl">
+        運動を記録しました。
+      </p>
+
+      <p class="mb-8 text-2xl font-bold text-gray-800 sm:text-3xl">
+        <%= @earned_points %>ptチャージされました。
+      </p>
+
+      <div class="mx-auto mb-8 flex h-64 w-64 items-center justify-center rounded-full bg-gray-200 text-2xl text-gray-700">
+        植物の画像
+      </div>
+
+      <% if @current_user_plant.present? %>
+        <% if @current_user_plant.next_stage.present? %>
+          <p class="mb-8 text-lg font-bold text-green-600">
+            次の成長までに必要なポイント
+            <span class="ml-2"><%= @current_user_plant.points_to_next_stage %>pt</span>
+          </p>
+        <% else %>
+          <p class="mb-8 text-lg font-bold text-green-600">
+            最終段階まで成長しています
+          </p>
+        <% end %>
+      <% end %>
+
+      <%= link_to "ホームに戻る",
+            home_path,
+            class: "inline-block rounded-lg bg-gray-600 px-8 py-3 font-bold text-white hover:bg-gray-700" %>
+    </div>
+  </div>
+</main>

--- a/app/views/exercise_logs/new.html.erb
+++ b/app/views/exercise_logs/new.html.erb
@@ -1,0 +1,60 @@
+<main class="flex-1 bg-gray-100 py-10">
+  <div class="mx-auto w-full max-w-xl px-4">
+    <div class="rounded-2xl bg-white p-6 shadow-sm sm:p-8">
+      <h1 class="mb-8 text-2xl font-bold text-gray-800 sm:text-3xl">
+        運動を記録する
+      </h1>
+
+      <% if flash.now[:alert].present? %>
+        <div class="mb-4 rounded-lg bg-red-100 px-4 py-3 text-sm text-red-700">
+          <%= flash.now[:alert] %>
+        </div>
+      <% end %>
+
+      <%= form_with model: @exercise_log,
+      url: exercise_log_path,
+      local: true,
+      data: { turbo: false },
+      class: "space-y-6" do |f| %>
+        <div>
+          <%= f.label :exercise_type, "運動種別", class: "mb-2 block text-sm font-bold text-gray-700" %>
+          <%= f.select :exercise_type,
+                [
+                  ["散歩", "walk"],
+                  ["筋トレ", "strength_training"],
+                  ["ストレッチ", "stretching"],
+                  ["ランニング", "running"],
+                  ["ヨガ", "yoga"]
+                ],
+                {},
+                class: "w-full rounded-lg border border-gray-300 px-4 py-3 focus:border-green-500 focus:outline-none" %>
+        </div>
+
+        <div>
+          <%= f.label :duration_minutes, "運動時間", class: "mb-2 block text-sm font-bold text-gray-700" %>
+          <%= f.select :duration_minutes,
+                [["10分", 10], ["20分", 20], ["30分", 30], ["40分", 40], ["50分", 50], ["60分", 60]],
+                {},
+                class: "w-full rounded-lg border border-gray-300 px-4 py-3 focus:border-green-500 focus:outline-none" %>
+        </div>
+
+        <div>
+          <%= f.label :memo, "メモ", class: "mb-2 block text-sm font-bold text-gray-700" %>
+          <%= f.text_area :memo,
+                rows: 6,
+                class: "w-full rounded-lg border border-gray-300 px-4 py-3 focus:border-green-500 focus:outline-none",
+                placeholder: "運動の内容をメモできます" %>
+        </div>
+
+        <div class="space-y-4 pt-4">
+          <%= f.submit "記録する",
+                class: "w-full rounded-lg bg-green-600 px-4 py-3 font-bold text-white hover:bg-green-700" %>
+
+          <%= link_to "戻る",
+                home_path,
+                class: "block w-full rounded-lg bg-gray-600 px-4 py-3 text-center font-bold text-white hover:bg-gray-700" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</main>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer class="bg-green-600 text-white">
   <div class="grid h-16 grid-cols-4 items-center text-center text-sm font-bold sm:h-20 sm:text-base">
     <%= link_to "ホーム", logged_in? ? home_path : root_path, class: "hover:opacity-80" %>
-    <%= link_to "運動記録", logged_in? ? "#" : new_signup_email_path, class: "hover:opacity-80" %>
+    <%= link_to "運動記録", logged_in? ? new_exercise_log_path : new_signup_email_path, class: "hover:opacity-80" %>
     <%= link_to "投稿", "#", class: "hover:opacity-80" %>
     <%= link_to "マイページ", logged_in? ? mypage_path : new_signup_email_path, class: "hover:opacity-80" %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,4 @@
 Rails.application.routes.draw do
-  get 'plants/index'
-  get 'mypages/show'
-  get 'mypages/edit'
-  get 'password_resets/new'
-  get 'password_resets/create'
-  get 'password_resets/edit'
-  get 'password_resets/update'
-  get 'sessions/new'
   root "pages#top"
   get "up" => "rails/health#show", as: :rails_health_check
 
@@ -23,11 +15,14 @@ Rails.application.routes.draw do
   delete "logout", to: "sessions#destroy"
 
   resource :password_reset, only: %i[new create edit update]
-
   resource :mypage, only: %i[show edit update]
 
   resources :plants, only: %i[index]
   post "plants/:id/select", to: "plants#select", as: :select_plant
+
+  resource :exercise_log, only: %i[new create] do
+    get :complete, on: :collection
+  end
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/db/migrate/20260311170017_create_exercise_logs.rb
+++ b/db/migrate/20260311170017_create_exercise_logs.rb
@@ -1,0 +1,13 @@
+class CreateExerciseLogs < ActiveRecord::Migration[7.1]
+  def change
+    create_table :exercise_logs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :exercise_type
+      t.integer :duration_minutes
+      t.text :memo
+      t.integer :earned_points
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260311171823_add_user_plant_to_exercise_logs.rb
+++ b/db/migrate/20260311171823_add_user_plant_to_exercise_logs.rb
@@ -1,0 +1,5 @@
+class AddUserPlantToExerciseLogs < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :exercise_logs, :user_plant, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_11_154830) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_11_171823) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,19 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_11_154830) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "exercise_logs", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "exercise_type"
+    t.integer "duration_minutes"
+    t.text "memo"
+    t.integer "earned_points"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_plant_id"
+    t.index ["user_id"], name: "index_exercise_logs_on_user_id"
+    t.index ["user_plant_id"], name: "index_exercise_logs_on_user_plant_id"
   end
 
   create_table "plant_stages", force: :cascade do |t|
@@ -98,6 +111,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_11_154830) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "exercise_logs", "user_plants"
+  add_foreign_key "exercise_logs", "users"
   add_foreign_key "plant_stages", "plants"
   add_foreign_key "user_plants", "plants"
   add_foreign_key "user_plants", "users"

--- a/test/controllers/exercise_logs_controller_test.rb
+++ b/test/controllers/exercise_logs_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class ExerciseLogsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get exercise_logs_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get exercise_logs_create_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/exercise_logs.yml
+++ b/test/fixtures/exercise_logs.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  exercise_type: 1
+  duration_minutes: 1
+  memo: MyText
+  earned_points: 1
+
+two:
+  user: two
+  exercise_type: 1
+  duration_minutes: 1
+  memo: MyText
+  earned_points: 1

--- a/test/models/exercise_log_test.rb
+++ b/test/models/exercise_log_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ExerciseLogTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
運動記録機能を実装し、運動内容に応じてポイントを加算できるようにしました。

## 変更内容
- `ExerciseLog` モデルを作成
- 運動記録用テーブルを追加
- 運動種別・運動時間・メモ・獲得ポイントを保存できるように実装
- 運動種別と運動時間に応じて獲得ポイントを計算する処理を追加
- `exercise_logs` を `user` に紐づけ
- `exercise_logs` を `user_plant` に紐づけ
- 運動記録入力画面を追加
- 運動記録完了画面を追加
- 運動記録時に `users.total_growth_points` を加算するように実装
- 運動記録時に育成中植物の `user_plants.accumulated_points` を加算するように実装
- フッターの「運動記録」から記録画面へ遷移できるように変更
- 最終段階まで成長している場合は完了画面の文言を切り替えるように修正

## 確認方法
- ログイン状態でフッターの「運動記録」を押す
- 運動記録画面に遷移することを確認
- 運動種別・運動時間・メモを入力して「記録する」を押す
- 完了画面に遷移することを確認
- 獲得ポイントが表示されることを確認
- `users.total_growth_points` が加算されることを確認
- 育成中植物の `user_plants.accumulated_points` が加算されることを確認
- 最終段階まで成長している場合は「最終段階まで成長しています」と表示されることを確認

Closes #14 