### PR TITLE
feat: 運動履歴一覧画面追加

### DIFF
--- a/app/controllers/exercise_logs_controller.rb
+++ b/app/controllers/exercise_logs_controller.rb
@@ -1,6 +1,10 @@
 class ExerciseLogsController < ApplicationController
   before_action :require_login
 
+  def index
+    @exercise_logs = current_user.exercise_logs.order(created_at: :desc)
+  end
+
   def new
     @exercise_log = ExerciseLog.new
   end

--- a/app/helpers/exercise_logs_helper.rb
+++ b/app/helpers/exercise_logs_helper.rb
@@ -1,2 +1,11 @@
 module ExerciseLogsHelper
+  def exercise_type_label(exercise_type)
+    {
+      "walk" => "散歩",
+      "strength_training" => "筋トレ",
+      "stretching" => "ストレッチ",
+      "running" => "ランニング",
+      "yoga" => "ヨガ"
+    }[exercise_type] || exercise_type
+  end
 end

--- a/app/views/exercise_logs/complete.html.erb
+++ b/app/views/exercise_logs/complete.html.erb
@@ -26,6 +26,12 @@
         <% end %>
       <% end %>
 
+      <div class="mb-4">
+        <%= link_to "履歴を見る",
+              exercise_logs_path,
+              class: "inline-block rounded-lg bg-green-600 px-8 py-3 font-bold text-white hover:bg-green-700" %>
+      </div>
+
       <%= link_to "ホームに戻る",
             home_path,
             class: "inline-block rounded-lg bg-gray-600 px-8 py-3 font-bold text-white hover:bg-gray-700" %>

--- a/app/views/exercise_logs/index.html.erb
+++ b/app/views/exercise_logs/index.html.erb
@@ -1,0 +1,40 @@
+<main class="flex-1 bg-gray-100 py-10">
+  <div class="mx-auto w-full max-w-3xl px-4">
+    <div class="rounded-2xl bg-white p-6 shadow-sm sm:p-8">
+      <h1 class="mb-6 text-2xl font-bold text-gray-800 sm:text-3xl">
+        運動記録履歴
+      </h1>
+
+      <% if @exercise_logs.present? %>
+        <div class="space-y-3">
+          <% @exercise_logs.each do |exercise_log| %>
+            <div class="border-b border-gray-200 pb-3">
+              <p class="font-bold text-gray-800">
+                <%= exercise_type_label(exercise_log.exercise_type) %>
+              </p>
+              <p class="text-sm text-gray-600">
+                <%= exercise_log.duration_minutes %>分 /
+                <%= exercise_log.earned_points %>pt /
+                <%= exercise_log.created_at.strftime("%Y/%m/%d %H:%M") %>
+              </p>
+
+              <% if exercise_log.memo.present? %>
+                <p class="mt-1 text-sm text-gray-700">
+                  メモ: <%= exercise_log.memo %>
+                </p>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="text-gray-600">まだ運動記録はありません。</p>
+      <% end %>
+
+      <div class="mt-6">
+        <%= link_to "戻る",
+              home_path,
+              class: "inline-block rounded-lg bg-gray-600 px-5 py-3 font-bold text-white hover:bg-gray-700" %>
+      </div>
+    </div>
+  </div>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
   resources :plants, only: %i[index]
   post "plants/:id/select", to: "plants#select", as: :select_plant
 
+  resources :exercise_logs, only: %i[index]
+
   resource :exercise_log, only: %i[new create] do
     get :complete, on: :collection
   end


### PR DESCRIPTION
## 概要
運動記録完了後に履歴一覧を確認できるようにしました。

## 変更内容
- `exercise_logs#index` を追加
- 運動記録履歴一覧ページを追加
- 運動記録完了画面に「履歴を見る」ボタンを追加

## 確認方法
- 運動記録を登録する
- 完了画面に「履歴を見る」ボタンが表示されることを確認
- ボタンクリックで `/exercise_logs` に遷移することを確認
- 一覧に運動種別・運動時間・獲得ポイント・記録日時が表示されることを確認

Closes #13 