### PR TITLE
feat: 運動記録履歴カレンダー表示

### DIFF
--- a/app/controllers/exercise_logs_controller.rb
+++ b/app/controllers/exercise_logs_controller.rb
@@ -2,11 +2,31 @@ class ExerciseLogsController < ApplicationController
   before_action :require_login
 
   def index
-    @exercise_logs = current_user.exercise_logs.order(created_at: :desc)
+    @target_date =
+      if params[:month].present?
+        Date.strptime(params[:month], "%Y-%m")
+      else
+        Date.current
+      end
+
+    @calendar_start = @target_date.beginning_of_month.beginning_of_week(:sunday)
+    @calendar_end   = @target_date.end_of_month.end_of_week(:sunday)
+
+    @exercise_dates = current_user.exercise_logs
+                                  .where(exercised_on: @calendar_start..@calendar_end)
+                                  .pluck(:exercised_on)
+                                  .uniq
+  end
+
+  def day
+    @date = Date.parse(params[:date])
+    @exercise_logs = current_user.exercise_logs
+                                 .where(exercised_on: @date)
+                                 .order(created_at: :desc)
   end
 
   def new
-    @exercise_log = ExerciseLog.new
+    @exercise_log = ExerciseLog.new(exercised_on: Date.current)
   end
 
   def create
@@ -40,6 +60,6 @@ class ExerciseLogsController < ApplicationController
   private
 
   def exercise_log_params
-    params.require(:exercise_log).permit(:exercise_type, :duration_minutes, :memo)
+    params.require(:exercise_log).permit(:exercise_type, :duration_minutes, :memo, :exercised_on)
   end
 end

--- a/app/models/exercise_log.rb
+++ b/app/models/exercise_log.rb
@@ -13,6 +13,7 @@ class ExerciseLog < ApplicationRecord
   validates :exercise_type, presence: true
   validates :duration_minutes, presence: true, numericality: { greater_than: 0 }
   validates :earned_points, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :exercised_on, presence: true
 
   EXERCISE_POINT_RATES = {
     "walk" => 5,

--- a/app/views/exercise_logs/day.html.erb
+++ b/app/views/exercise_logs/day.html.erb
@@ -1,0 +1,38 @@
+<main class="flex-1 bg-gray-100 py-10">
+  <div class="mx-auto w-full max-w-3xl px-4">
+    <div class="rounded-2xl bg-white p-6 shadow-sm sm:p-8">
+      <h1 class="mb-6 text-2xl font-bold text-gray-800 sm:text-3xl">
+        <%= @date.strftime("%Y/%m/%d") %> の運動記録
+      </h1>
+
+      <% if @exercise_logs.present? %>
+        <div class="space-y-4">
+          <% @exercise_logs.each do |exercise_log| %>
+            <div class="border-b border-gray-200 pb-4">
+              <p class="font-bold text-gray-800">
+                <%= exercise_type_label(exercise_log.exercise_type) %>
+              </p>
+              <p class="text-sm text-gray-600">
+                <%= exercise_log.duration_minutes %>分 / <%= exercise_log.earned_points %>pt
+              </p>
+
+              <% if exercise_log.memo.present? %>
+                <p class="mt-2 text-sm text-gray-700">
+                  メモ: <%= exercise_log.memo %>
+                </p>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="text-gray-600">この日の運動記録はありません。</p>
+      <% end %>
+
+      <div class="mt-6">
+        <%= link_to "カレンダーに戻る",
+              exercise_logs_path(month: @date.strftime("%Y-%m")),
+              class: "inline-block rounded-lg bg-gray-600 px-5 py-3 font-bold text-white hover:bg-gray-700" %>
+      </div>
+    </div>
+  </div>
+</main>

--- a/app/views/exercise_logs/index.html.erb
+++ b/app/views/exercise_logs/index.html.erb
@@ -1,40 +1,50 @@
 <main class="flex-1 bg-gray-100 py-10">
-  <div class="mx-auto w-full max-w-3xl px-4">
-    <div class="rounded-2xl bg-white p-6 shadow-sm sm:p-8">
-      <h1 class="mb-6 text-2xl font-bold text-gray-800 sm:text-3xl">
-        運動記録履歴
-      </h1>
+  <div class="mx-auto w-full max-w-5xl px-4">
+    <h1 class="mb-8 text-2xl font-bold text-gray-800 sm:text-3xl">
+      運動履歴
+    </h1>
 
-      <% if @exercise_logs.present? %>
-        <div class="space-y-3">
-          <% @exercise_logs.each do |exercise_log| %>
-            <div class="border-b border-gray-200 pb-3">
-              <p class="font-bold text-gray-800">
-                <%= exercise_type_label(exercise_log.exercise_type) %>
-              </p>
-              <p class="text-sm text-gray-600">
-                <%= exercise_log.duration_minutes %>分 /
-                <%= exercise_log.earned_points %>pt /
-                <%= exercise_log.created_at.strftime("%Y/%m/%d %H:%M") %>
-              </p>
+    <div class="mb-8 flex items-center justify-between">
+      <h2 class="text-3xl font-bold text-gray-800">
+        <%= @target_date.strftime("%Y年%-m月") %>
+      </h2>
 
-              <% if exercise_log.memo.present? %>
-                <p class="mt-1 text-sm text-gray-700">
-                  メモ: <%= exercise_log.memo %>
-                </p>
-              <% end %>
-            </div>
-          <% end %>
-        </div>
-      <% else %>
-        <p class="text-gray-600">まだ運動記録はありません。</p>
-      <% end %>
-
-      <div class="mt-6">
-        <%= link_to "戻る",
-              home_path,
-              class: "inline-block rounded-lg bg-gray-600 px-5 py-3 font-bold text-white hover:bg-gray-700" %>
+      <div class="flex gap-4 text-3xl">
+        <%= link_to "‹", exercise_logs_path(month: @target_date.prev_month.strftime("%Y-%m")), class: "text-gray-400 hover:text-gray-700" %>
+        <%= link_to "›", exercise_logs_path(month: @target_date.next_month.strftime("%Y-%m")), class: "text-gray-700 hover:text-black" %>
       </div>
+    </div>
+
+    <div class="mb-4 grid grid-cols-7 text-center text-xl font-bold text-gray-500">
+      <div>日</div>
+      <div>月</div>
+      <div>火</div>
+      <div>水</div>
+      <div>木</div>
+      <div>金</div>
+      <div>土</div>
+    </div>
+
+    <div class="grid grid-cols-7 gap-3">
+      <% (@calendar_start..@calendar_end).each do |date| %>
+        <% in_month = date.month == @target_date.month %>
+        <% exercised = @exercise_dates.include?(date) %>
+
+        <%= link_to exercise_logs_by_date_path(date: date.to_s),
+              class: "min-h-[100px] rounded-2xl border border-gray-300 bg-white p-3 #{in_month ? 'text-gray-900' : 'text-gray-300'} hover:bg-gray-50" do %>
+          <div class="text-2xl font-bold"><%= date.day %></div>
+
+          <% if exercised %>
+            <div class="mt-4 text-center text-2xl">🏃</div>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="mt-8">
+      <%= link_to "戻る",
+            home_path,
+            class: "inline-block rounded-lg bg-gray-600 px-5 py-3 font-bold text-white hover:bg-gray-700" %>
     </div>
   </div>
 </main>

--- a/app/views/exercise_logs/new.html.erb
+++ b/app/views/exercise_logs/new.html.erb
@@ -31,6 +31,12 @@
         </div>
 
         <div>
+          <%= f.label :exercised_on, "運動日", class: "mb-2 block text-sm font-bold text-gray-700" %>
+          <%= f.date_field :exercised_on,
+                class: "w-full rounded-lg border border-gray-300 px-4 py-3 focus:border-green-500 focus:outline-none" %>
+        </div>
+
+        <div>
           <%= f.label :duration_minutes, "運動時間", class: "mb-2 block text-sm font-bold text-gray-700" %>
           <%= f.select :duration_minutes,
                 [["10分", 10], ["20分", 20], ["30分", 30], ["40分", 40], ["50分", 50], ["60分", 60]],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   post "plants/:id/select", to: "plants#select", as: :select_plant
 
   resources :exercise_logs, only: %i[index]
+  get "exercise_logs/date/:date", to: "exercise_logs#day", as: :exercise_logs_by_date
 
   resource :exercise_log, only: %i[new create] do
     get :complete, on: :collection

--- a/db/migrate/20260312144345_add_exercised_on_to_exercise_logs.rb
+++ b/db/migrate/20260312144345_add_exercised_on_to_exercise_logs.rb
@@ -1,0 +1,5 @@
+class AddExercisedOnToExerciseLogs < ActiveRecord::Migration[7.1]
+  def change
+    add_column :exercise_logs, :exercised_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_11_171823) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_12_144345) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_11_171823) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_plant_id"
+    t.date "exercised_on"
     t.index ["user_id"], name: "index_exercise_logs_on_user_id"
     t.index ["user_plant_id"], name: "index_exercise_logs_on_user_plant_id"
   end


### PR DESCRIPTION
## 概要
運動履歴一覧画面をカレンダーUIに変更し、運動した日にアイコンを表示できるようにしました。
あわせて、日付クリックでその日の運動記録詳細を確認できるようにしました。

## 変更内容
- `exercise_logs` に `exercised_on` カラムを追加
- 運動記録入力画面に「運動日」項目を追加
- `ExerciseLogsController#index` をカレンダー表示用に修正
- `ExerciseLogsController#day` を追加
- 運動履歴一覧画面をカレンダーUIに変更
- 運動した日にアイコンを表示するように実装
- 日付クリックでその日の運動記録詳細画面へ遷移できるように実装
- 月送りで過去月・未来月を閲覧できるように実装
- 完了画面の「履歴を見る」導線をカレンダー画面に変更

## 確認方法
- 運動記録画面で運動日を指定して記録できることを確認
- 完了画面から「履歴を見る」でカレンダー画面へ遷移できることを確認
- 記録した日にアイコンが表示されることを確認
- 日付をクリックするとその日の詳細画面へ遷移できることを確認
- その日の運動記録が一覧表示されることを確認
- 前月・次月へ移動できることを確認

Closes #27 