### PR TITLE
feat: コミュニティ投稿の一覧表示と投稿作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,28 @@
+class PostsController < ApplicationController
+  before_action :require_login, only: %i[new create]
+
+  def index
+    @posts = Post.includes(:user).with_attached_image.order(created_at: :desc)
+  end
+
+  def new
+    @post = Post.new
+  end
+
+  def create
+    @post = current_user.posts.new(post_params)
+
+    if @post.save
+      redirect_to posts_path, notice: "投稿しました"
+    else
+      flash.now[:alert] = @post.errors.full_messages.join(", ")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:body, :image)
+  end
+end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,0 +1,2 @@
+module PostsHelper
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,7 @@
+class Post < ApplicationRecord
+  belongs_to :user
+
+  has_one_attached :image
+
+  validates :body, presence: true, length: { maximum: 500 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   has_many :user_plants, dependent: :destroy
   has_many :plants, through: :user_plants
   has_many :exercise_logs, dependent: :destroy
+  has_many :posts, dependent: :destroy
 
   attr_accessor :password, :password_confirmation
 

--- a/app/views/posts/create.html.erb
+++ b/app/views/posts/create.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Posts#create</h1>
+  <p>Find me in app/views/posts/create.html.erb</p>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,47 @@
+<main class="flex-1 bg-gray-100 py-10">
+  <div class="mx-auto w-full max-w-3xl px-4">
+    <div class="mb-8 flex items-center justify-between">
+      <h1 class="text-2xl font-bold text-gray-800 sm:text-3xl">
+        みんなの投稿一覧
+      </h1>
+
+      <% if logged_in? %>
+        <%= link_to "投稿する",
+              new_post_path,
+              class: "rounded-lg bg-green-600 px-5 py-3 font-bold text-white hover:bg-green-700" %>
+      <% end %>
+    </div>
+
+    <% if @posts.present? %>
+      <div class="space-y-8">
+        <% @posts.each do |post| %>
+          <div class="border-t border-b border-gray-400 py-5">
+            <div class="mb-2 text-sm text-gray-700">
+              <%= post.user.display_name %>
+              累計 <%= number_with_delimiter(post.user.total_growth_points) %>pt
+              <% if post.user.user_plants.growing.first&.plant&.name.present? %>
+                植物名：<%= post.user.user_plants.growing.first.plant.name %>
+              <% end %>
+            </div>
+
+            <p class="mb-4 text-sm text-gray-600">
+              <%= post.created_at.strftime("%Y.%m.%d") %>
+            </p>
+
+            <p class="mb-4 whitespace-pre-wrap text-gray-800">
+              <%= truncate(post.body, length: 120) %>
+            </p>
+
+            <% if post.image.attached? %>
+              <div class="overflow-hidden rounded-lg bg-gray-200">
+                <%= image_tag post.image, class: "h-auto w-full object-cover" %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="text-gray-600">まだ投稿はありません。</p>
+    <% end %>
+  </div>
+</main>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,43 @@
+<main class="flex-1 bg-gray-100 py-10">
+  <div class="mx-auto w-full max-w-xl px-4">
+    <div class="rounded-2xl bg-white p-6 shadow-sm sm:p-8">
+      <h1 class="mb-8 text-2xl font-bold text-gray-800 sm:text-3xl">
+        投稿
+      </h1>
+
+      <% if flash.now[:alert].present? %>
+        <div class="mb-4 rounded-lg bg-red-100 px-4 py-3 text-sm text-red-700">
+          <%= flash.now[:alert] %>
+        </div>
+      <% end %>
+
+      <%= form_with model: @post,
+            url: posts_path,
+            local: true,
+            data: { turbo: false },
+            class: "space-y-6" do |f| %>
+        <div>
+          <%= f.label :body, "本文", class: "mb-2 block text-sm font-bold text-gray-700" %>
+          <%= f.text_area :body,
+                rows: 8,
+                class: "w-full rounded-lg border border-gray-300 px-4 py-3 focus:border-green-500 focus:outline-none" %>
+        </div>
+
+        <div>
+          <%= f.label :image, "画像", class: "mb-2 block text-sm font-bold text-gray-700" %>
+          <%= f.file_field :image,
+                class: "w-full rounded-lg border border-gray-300 px-4 py-3 focus:border-green-500 focus:outline-none" %>
+        </div>
+
+        <div class="space-y-4 pt-4">
+          <%= f.submit "投稿する",
+                class: "w-full rounded-lg bg-green-600 px-4 py-3 font-bold text-white hover:bg-green-700" %>
+
+          <%= link_to "戻る",
+                posts_path,
+                class: "block w-full rounded-lg bg-gray-600 px-4 py-3 text-center font-bold text-white hover:bg-gray-700" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</main>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="grid h-16 grid-cols-4 items-center text-center text-sm font-bold sm:h-20 sm:text-base">
     <%= link_to "ホーム", logged_in? ? home_path : root_path, class: "hover:opacity-80" %>
     <%= link_to "運動記録", logged_in? ? new_exercise_log_path : new_signup_email_path, class: "hover:opacity-80" %>
-    <%= link_to "投稿", "#", class: "hover:opacity-80" %>
+    <%= link_to "投稿", posts_path, class: "hover:opacity-80" %>
     <%= link_to "マイページ", logged_in? ? mypage_path : new_signup_email_path, class: "hover:opacity-80" %>
   </div>
 </footer>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get 'posts/index'
+  get 'posts/new'
+  get 'posts/create'
   root "pages#top"
   get "up" => "rails/health#show", as: :rails_health_check
 
@@ -24,6 +27,8 @@ Rails.application.routes.draw do
     get :complete, on: :collection
     get "date/:date", to: "exercise_logs#day", on: :collection, as: :by_date
   end
+
+  resources :posts, only: %i[index new create]
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/db/migrate/20260313170027_create_posts.rb
+++ b/db/migrate/20260313170027_create_posts.rb
@@ -1,0 +1,10 @@
+class CreatePosts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :posts do |t|
+      t.references :user, null: false, foreign_key: true
+      t.text :body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_12_144345) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_13_170027) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,6 +74,14 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_12_144345) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "posts", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
   create_table "user_plants", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "plant_id", null: false
@@ -115,6 +123,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_12_144345) do
   add_foreign_key "exercise_logs", "user_plants"
   add_foreign_key "exercise_logs", "users"
   add_foreign_key "plant_stages", "plants"
+  add_foreign_key "posts", "users"
   add_foreign_key "user_plants", "plants"
   add_foreign_key "user_plants", "users"
 end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class PostsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get posts_index_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get posts_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get posts_create_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  body: MyText
+
+two:
+  user: two
+  body: MyText

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
コミュニティ投稿の一覧表示と投稿作成機能を実装

## 変更内容
- `Post` モデルを作成
- 投稿テーブルを追加
- `Post` と `User` の関連を追加
- 投稿画像を Active Storage で添付できるように実装
- 投稿一覧ページを追加
- 投稿入力画面を追加
- 投稿作成処理を追加
- 投稿一覧に本文・画像・投稿者名・累計ポイント・植物名・投稿日を表示するように実装
- 一覧ページの「投稿する」ボタンから投稿入力画面へ遷移できるように実装
- 投稿一覧は未ログインユーザーでも閲覧できるように実装
- 「投稿する」ボタンと投稿作成はログインユーザーのみに制限

## 確認方法
- 未ログイン状態で投稿一覧ページを開けることを確認
- 未ログイン状態では「投稿する」ボタンが表示されないことを確認
- ログイン状態で投稿一覧ページを開く
- 「投稿する」ボタンが表示されることを確認
- 投稿入力画面へ遷移できることを確認
- 本文を入力して投稿できることを確認
- 画像を添付して投稿できることを確認
- 投稿後、一覧ページに戻り新しい投稿が表示されることを確認

Closes #17
Closes #18 