### PR TITLE
feat: コミュニティ投稿の詳細表示と編集機能の追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,8 +1,13 @@
 class PostsController < ApplicationController
-  before_action :require_login, only: %i[new create]
+  before_action :require_login, only: %i[new create edit update]
+  before_action :set_post, only: %i[show edit update]
+  before_action :ensure_own_post, only: %i[edit update]
 
   def index
     @posts = Post.includes(:user).with_attached_image.order(created_at: :desc)
+  end
+
+  def show
   end
 
   def new
@@ -13,14 +18,34 @@ class PostsController < ApplicationController
     @post = current_user.posts.new(post_params)
 
     if @post.save
-      redirect_to posts_path, notice: "投稿しました"
+      redirect_to post_path(@post), notice: "投稿しました"
     else
       flash.now[:alert] = @post.errors.full_messages.join(", ")
       render :new, status: :unprocessable_entity
     end
   end
 
+  def edit
+  end
+
+  def update
+    if @post.update(post_params)
+      redirect_to post_path(@post), notice: "投稿を更新しました"
+    else
+      flash.now[:alert] = @post.errors.full_messages.join(", ")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
+
+  def set_post
+    @post = Post.find(params[:id])
+  end
+
+  def ensure_own_post
+    redirect_to posts_path, alert: "権限がありません" unless @post.user == current_user
+  end
 
   def post_params
     params.require(:post).permit(:body, :image)

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,42 @@
+<main class="flex-1 bg-gray-100 py-10">
+  <div class="mx-auto w-full max-w-xl px-4">
+    <div class="rounded-2xl bg-white p-6 shadow-sm sm:p-8">
+      <h1 class="mb-8 text-2xl font-bold text-gray-800 sm:text-3xl">
+        投稿を編集
+      </h1>
+
+      <% if flash.now[:alert].present? %>
+        <div class="mb-4 rounded-lg bg-red-100 px-4 py-3 text-sm text-red-700">
+          <%= flash.now[:alert] %>
+        </div>
+      <% end %>
+
+      <%= form_with model: @post,
+            local: true,
+            data: { turbo: false },
+            class: "space-y-6" do |f| %>
+        <div>
+          <%= f.label :body, "本文", class: "mb-2 block text-sm font-bold text-gray-700" %>
+          <%= f.text_area :body,
+                rows: 8,
+                class: "w-full rounded-lg border border-gray-300 px-4 py-3 focus:border-green-500 focus:outline-none" %>
+        </div>
+
+        <div>
+          <%= f.label :image, "画像", class: "mb-2 block text-sm font-bold text-gray-700" %>
+          <%= f.file_field :image,
+                class: "w-full rounded-lg border border-gray-300 px-4 py-3 focus:border-green-500 focus:outline-none" %>
+        </div>
+
+        <div class="space-y-4 pt-4">
+          <%= f.submit "更新する",
+                class: "w-full rounded-lg bg-green-600 px-4 py-3 font-bold text-white hover:bg-green-700" %>
+
+          <%= link_to "戻る",
+                post_path(@post),
+                class: "block w-full rounded-lg bg-gray-600 px-4 py-3 text-center font-bold text-white hover:bg-gray-700" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</main>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -15,7 +15,7 @@
     <% if @posts.present? %>
       <div class="space-y-8">
         <% @posts.each do |post| %>
-          <div class="border-t border-b border-gray-400 py-5">
+          <%= link_to post_path(post), class: "block border-t border-b border-gray-400 py-5 hover:bg-gray-50" do %>
             <div class="mb-2 text-sm text-gray-700">
               <%= post.user.display_name %>
               累計 <%= number_with_delimiter(post.user.total_growth_points) %>pt
@@ -37,7 +37,7 @@
                 <%= image_tag post.image, class: "h-auto w-full object-cover" %>
               </div>
             <% end %>
-          </div>
+          <% end %>
         <% end %>
       </div>
     <% else %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,41 @@
+<main class="flex-1 bg-gray-100 py-10">
+  <div class="mx-auto w-full max-w-3xl px-4">
+    <div class="rounded-2xl bg-white p-6 shadow-sm sm:p-8">
+      <div class="mb-2 text-sm text-gray-700">
+        <%= @post.user.display_name %>
+        累計 <%= number_with_delimiter(@post.user.total_growth_points) %>pt
+        <% if @post.user.user_plants.growing.first&.plant&.name.present? %>
+          植物名：<%= @post.user.user_plants.growing.first.plant.name %>
+        <% end %>
+      </div>
+
+      <p class="mb-6 text-sm text-gray-600">
+        <%= @post.created_at.strftime("%Y.%m.%d") %>
+      </p>
+
+      <p class="mb-6 whitespace-pre-wrap text-lg text-gray-800">
+        <%= @post.body %>
+      </p>
+
+      <% if @post.image.attached? %>
+        <div class="mb-8 overflow-hidden rounded-lg bg-gray-200">
+          <%= image_tag @post.image, class: "h-auto w-full object-cover" %>
+        </div>
+      <% end %>
+
+      <% if logged_in? && @post.user == current_user %>
+        <div class="mb-4">
+          <%= link_to "編集する",
+                edit_post_path(@post),
+                class: "block w-full rounded-lg bg-gray-600 px-4 py-3 text-center font-bold text-white hover:bg-gray-700" %>
+        </div>
+      <% end %>
+
+      <div>
+        <%= link_to "一覧に戻る",
+              posts_path,
+              class: "block w-full rounded-lg bg-green-600 px-4 py-3 text-center font-bold text-white hover:bg-green-700" %>
+      </div>
+    </div>
+  </div>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
     get "date/:date", to: "exercise_logs#day", on: :collection, as: :by_date
   end
 
-  resources :posts, only: %i[index new create]
+  resources :posts, only: %i[index new create show edit update]
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end


### PR DESCRIPTION
## 概要
コミュニティ投稿の詳細表示と編集機能を実装

## 変更内容
- 投稿一覧の各投稿から詳細ページへ遷移できるように実装
- 投稿詳細ページを追加
- 投稿詳細ページに本文・画像・投稿者情報・投稿日を表示するように実装
- 投稿編集画面を追加
- 投稿更新処理を追加
- 投稿編集はログインユーザーかつ投稿者本人のみに制限

## 確認方法
- 投稿一覧から各投稿をクリックして詳細ページへ遷移できることを確認
- 投稿詳細ページに本文・画像・投稿者情報・投稿日が表示されることを確認
- 自分の投稿だけ「編集する」ボタンが表示されることを確認
- 他人の投稿では「編集する」ボタンが表示されないことを確認
- 自分の投稿の編集画面へ遷移できることを確認
- 本文や画像を更新できることを確認
- 更新後、投稿詳細画面に内容が反映されることを確認

Closes #19 