### PR TITLE
feat: 投稿の削除機能追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
-  before_action :require_login, only: %i[new create edit update]
-  before_action :set_post, only: %i[show edit update]
-  before_action :ensure_own_post, only: %i[edit update]
+  before_action :require_login, only: %i[new create edit update destroy]
+  before_action :set_post, only: %i[show edit update destroy]
+  before_action :ensure_own_post, only: %i[edit update destroy]
 
   def index
     @posts = Post.includes(:user).with_attached_image.order(created_at: :desc)
@@ -35,6 +35,11 @@ class PostsController < ApplicationController
       flash.now[:alert] = @post.errors.full_messages.join(", ")
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @post.destroy!
+    redirect_to posts_path, notice: "投稿を削除しました"
   end
 
   private

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -22,7 +22,7 @@
           <%= image_tag @post.image, class: "h-auto w-full object-cover" %>
         </div>
       <% end %>
-
+      
       <% if logged_in? && @post.user == current_user %>
         <div class="mb-4">
           <%= link_to "編集する",
@@ -31,11 +31,21 @@
         </div>
       <% end %>
 
-      <div>
+      <div class="mb-4">
         <%= link_to "一覧に戻る",
               posts_path,
               class: "block w-full rounded-lg bg-green-600 px-4 py-3 text-center font-bold text-white hover:bg-green-700" %>
       </div>
+
+      <% if logged_in? && @post.user == current_user %>
+        <div class="text-center">
+          <%= button_to "投稿を削除する",
+                post_path(@post),
+                method: :delete,
+                data: { turbo_confirm: "この投稿を削除しますか？" },
+                class: "text-lg text-gray-700 underline hover:text-red-600 bg-transparent border-0 p-0" %>
+        </div>
+      <% end %>
     </div>
   </div>
 </main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
     get "date/:date", to: "exercise_logs#day", on: :collection, as: :by_date
   end
 
-  resources :posts, only: %i[index new create show edit update]
+  resources :posts, only: %i[index new create show edit update destroy]
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end


### PR DESCRIPTION
## 概要
コミュニティ投稿の削除機能を実装

## 変更内容
- 投稿の `destroy` ルーティングを追加
- `PostsController` に `destroy` アクションを追加
- 投稿詳細ページに「投稿を削除する」ボタンを追加
- 削除ボタンは投稿者本人のときだけ表示するように実装
- 削除時に確認ダイアログを表示するように実装
- 投稿削除後は投稿一覧ページへ遷移するように実装

## 確認方法
- 自分の投稿詳細ページを開く
- 「投稿を削除する」ボタンが表示されることを確認
- ボタン押下時に確認ダイアログが表示されることを確認
- OKで投稿が削除されることを確認
- 削除後に投稿一覧ページへ遷移することを確認
- 一覧から該当投稿が消えていることを確認
- 他人の投稿では削除ボタンが表示されないことを確認

Closes #20 