### PR TITLE
feat: 利用規約、プライバシーポリシー追加

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,10 @@
 class PagesController < ApplicationController
   def top
   end
+
+  def privacy
+  end
+
+  def terms
+  end
 end

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -166,8 +166,8 @@
     </div>
 
     <div class="mt-8 flex flex-wrap justify-center gap-x-8 gap-y-4 pb-4 text-sm text-slate-500 underline sm:text-base">
-      <a href="#">プライバシーポリシー</a>
-      <a href="#">利用規約</a>
+      <%= link_to "プライバシーポリシー", privacy_policy_path %>
+      <%= link_to "利用規約", terms_path %>
     </div>
   </div>
 </main>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,0 +1,60 @@
+<main class="flex-1 bg-[#f7f8f6] py-8 sm:py-10">
+  <div class="mx-auto w-full max-w-4xl px-4 sm:px-6">
+    <section class="rounded-[32px] border border-gray-200/80 bg-white p-6 shadow-[0_10px_30px_rgba(15,23,42,0.04)] sm:p-8 lg:p-10">
+      <div class="mx-auto max-w-3xl">
+        <div class="mb-10 text-center">
+          <p class="text-[12px] font-semibold tracking-[0.24em] text-green-700/80">
+            PRIVACY POLICY
+          </p>
+          <h1 class="mt-3 text-3xl font-bold tracking-tight text-slate-900 sm:text-5xl">
+            プライバシーポリシー
+          </h1>
+        </div>
+
+        <div class="space-y-8 text-slate-700">
+          <section>
+            <h2 class="text-xl font-bold text-slate-900">1. 取得する情報</h2>
+            <p class="mt-3 leading-8">
+              当サービスでは、会員登録やお問い合わせの際に、メールアドレス、ユーザー名、プロフィール情報等を取得することがあります。
+            </p>
+          </section>
+
+          <section>
+            <h2 class="text-xl font-bold text-slate-900">2. 利用目的</h2>
+            <p class="mt-3 leading-8">
+              取得した情報は、本人確認、サービス提供、ユーザーサポート、サービス改善、不正利用防止のために利用します。
+            </p>
+          </section>
+
+          <section>
+            <h2 class="text-xl font-bold text-slate-900">3. 第三者提供</h2>
+            <p class="mt-3 leading-8">
+              法令に基づく場合を除き、本人の同意なく個人情報を第三者へ提供しません。
+            </p>
+          </section>
+
+          <section>
+            <h2 class="text-xl font-bold text-slate-900">4. 安全管理</h2>
+            <p class="mt-3 leading-8">
+              個人情報への不正アクセス、漏えい、滅失、毀損の防止に努め、適切な安全管理措置を講じます。
+            </p>
+          </section>
+
+          <section>
+            <h2 class="text-xl font-bold text-slate-900">5. 改定</h2>
+            <p class="mt-3 leading-8">
+              本ポリシーは、必要に応じて改定することがあります。重要な変更がある場合は、適切な方法で通知します。
+            </p>
+          </section>
+
+          <section>
+            <h2 class="text-xl font-bold text-slate-900">6. お問い合わせ</h2>
+            <p class="mt-3 leading-8">
+              本ポリシーに関するお問い合わせは、運営者までご連絡ください。
+            </p>
+          </section>
+        </div>
+      </div>
+    </section>
+  </div>
+</main>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,0 +1,60 @@
+<main class="flex-1 bg-[#f7f8f6] py-8 sm:py-10">
+  <div class="mx-auto w-full max-w-4xl px-4 sm:px-6">
+    <section class="rounded-[32px] border border-gray-200/80 bg-white p-6 shadow-[0_10px_30px_rgba(15,23,42,0.04)] sm:p-8 lg:p-10">
+      <div class="mx-auto max-w-3xl">
+        <div class="mb-10 text-center">
+          <p class="text-[12px] font-semibold tracking-[0.24em] text-green-700/80">
+            TERMS OF SERVICE
+          </p>
+          <h1 class="mt-3 text-3xl font-bold tracking-tight text-slate-900 sm:text-5xl">
+            利用規約
+          </h1>
+        </div>
+
+        <div class="space-y-8 text-slate-700">
+          <section>
+            <h2 class="text-xl font-bold text-slate-900">1. 適用</h2>
+            <p class="mt-3 leading-8">
+              本規約は、ユーザーと当サービス運営者との間の一切の関係に適用されます。
+            </p>
+          </section>
+
+          <section>
+            <h2 class="text-xl font-bold text-slate-900">2. 会員登録</h2>
+            <p class="mt-3 leading-8">
+              ユーザーは、定められた方法により登録を申請し、運営者がこれを承認することで会員登録が完了します。
+            </p>
+          </section>
+
+          <section>
+            <h2 class="text-xl font-bold text-slate-900">3. 禁止事項</h2>
+            <p class="mt-3 leading-8">
+              ユーザーは、法令または公序良俗に反する行為、不正アクセス、他者への迷惑行為、サービス運営を妨げる行為をしてはなりません。
+            </p>
+          </section>
+
+          <section>
+            <h2 class="text-xl font-bold text-slate-900">4. サービス内容の変更</h2>
+            <p class="mt-3 leading-8">
+              当サービスは、ユーザーへの事前通知なく、サービス内容を変更または停止することがあります。
+            </p>
+          </section>
+
+          <section>
+            <h2 class="text-xl font-bold text-slate-900">5. 免責事項</h2>
+            <p class="mt-3 leading-8">
+              当サービスは、提供内容の正確性・完全性・有用性について保証するものではなく、利用により生じた損害について責任を負いません。
+            </p>
+          </section>
+
+          <section>
+            <h2 class="text-xl font-bold text-slate-900">6. 規約の変更</h2>
+            <p class="mt-3 leading-8">
+              本規約は、必要に応じて変更することがあります。変更後は、当サービス上に掲載した時点で効力を生じます。
+            </p>
+          </section>
+        </div>
+      </div>
+    </section>
+  </div>
+</main>

--- a/app/views/pages/top.html.erb
+++ b/app/views/pages/top.html.erb
@@ -147,8 +147,8 @@
     </section>
 
     <div class="mt-8 flex flex-wrap justify-center gap-x-8 gap-y-4 text-sm text-gray-600 underline sm:text-base">
-      <a href="#">プライバシーポリシー</a>
-      <a href="#">利用規約</a>
+      <%= link_to "プライバシーポリシー", privacy_policy_path %>
+      <%= link_to "利用規約", terms_path %>
     </div>
   </div>
 </main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,5 +24,8 @@ Rails.application.routes.draw do
 
   resources :posts, only: %i[index new create show edit update destroy]
 
+  get "privacy", to: "pages#privacy", as: :privacy_policy
+  get "terms", to: "pages#terms", as: :terms
+
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end


### PR DESCRIPTION
## 概要
プライバシーポリシーと利用規約の静的ページを追加
あわせて、未ログイン時トップページとログイン後ホーム画面のフッターリンクから遷移できるように修正

## 変更内容
- `privacy` ページを追加
- `terms` ページを追加
- `PagesController` に `privacy` / `terms` アクションを追加
- `routes.rb` に `privacy_policy_path` / `terms_path` を追加

## 確認方法
- 未ログイン状態でトップページを開く
- フッターの「プライバシーポリシー」を押してページ遷移できることを確認
- フッターの「利用規約」を押してページ遷移できることを確認
- ログイン後ホーム画面下部の「プライバシーポリシー」を押してページ遷移できることを確認
- ログイン後ホーム画面下部の「利用規約」を押してページ遷移できることを確認