### PR TITLE
fix: 運動記録完了画面バグ修正

### DIFF
--- a/app/views/exercise_logs/complete.html.erb
+++ b/app/views/exercise_logs/complete.html.erb
@@ -13,8 +13,8 @@
         </p>
 
         <div class="mt-10 flex justify-center">
-          <% if @current_user_plant&.plant&.image&.attached? %>
-            <%= image_tag @current_user_plant.plant.image,
+          <% if @current_user_plant&.plant&.image_exists? %>
+            <%= image_tag @current_user_plant.plant.image_file_name,
                   class: "h-56 w-56 rounded-full border border-gray-200 object-contain shadow-sm sm:h-64 sm:w-64" %>
           <% else %>
             <div class="flex h-56 w-56 items-center justify-center rounded-full bg-gray-100 text-xl text-gray-600 sm:h-64 sm:w-64">


### PR DESCRIPTION
## 概要
植物画像の表示方法変更に伴う不具合を修正しました。

## 変更内容
- 植物画像の参照方法を修正
- Active Storage 前提の記述を削除
- 植物一覧、植物詳細、ホーム、運動記録完了画面の表示を修正

## 確認
- ホームで植物画像が表示される
- 植物一覧で植物画像が表示される
- 植物詳細で植物画像が表示される
- 運動記録完了画面でエラーにならない